### PR TITLE
Change cursor depending on mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,10 @@ export default class HanziWriterPlugin extends Plugin {
 
             // Create target div for HanziWriter
             const target = container.createDiv({ cls: 'hanzi-writer-target' });
+
+            if (config.quizOnStart !== false) {
+                target.addClass("hanzi-writer-quiz");
+            }
             
             // Set up default options with theme colors
             const options = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,11 +75,17 @@ export default class HanziWriterPlugin extends Plugin {
             
             // Animate button
             const animateButton = buttonContainer.createEl('button', { text: 'Animate' });
-            animateButton.onclick = () => writer.animateCharacter();
+            animateButton.onclick = () => {
+                target.removeClass("hanzi-writer-quiz");
+                writer.animateCharacter();
+            }
 
             // Quiz button
             const quizButton = buttonContainer.createEl('button', { text: 'Quiz' });
-            quizButton.onclick = () => writer.quiz();
+            quizButton.onclick = () => {
+                target.addClass("hanzi-writer-quiz");
+                writer.quiz();
+            }
 
             // Debug button
             if (this.settings.showDebug) {

--- a/styles.css
+++ b/styles.css
@@ -4,12 +4,17 @@
     border-radius: 4px;
     margin: 1em 0;
     text-align: center;
+    cursor: default;
 }
 
 .hanzi-writer-target {
     display: inline-block;
     background-color: var(--background-primary);
     border-radius: 4px;
+}
+
+.hanzi-writer-quiz {
+    cursor: crosshair;
 }
 
 .hanzi-writer-controls {


### PR DESCRIPTION
Sets cursor to `default` (arrow on most devices) while in view / other modes, and sets it to `crosshair` when in quiz mode to make it easier to see where you're drawing.